### PR TITLE
improve search performance

### DIFF
--- a/src/Actions/SearchRequestAction.php
+++ b/src/Actions/SearchRequestAction.php
@@ -82,8 +82,8 @@ class SearchRequestAction implements ActionInterface
 
     private function getNextMatchingExpectation(?Expectation $lastFound, ServerRequestInterface $request, Expectation $expectation): ?Expectation
     {
-        if ($this->comparator->equals($request, $expectation)) {
-            if (null === $lastFound || $expectation->getPriority() > $lastFound->getPriority()) {
+        if (null === $lastFound || $expectation->getPriority() > $lastFound->getPriority()) {
+            if ($this->comparator->equals($request, $expectation)) {
                 $lastFound = $expectation;
             }
         }


### PR DESCRIPTION
With large expectation sets (> 100 entries) we saw processing times beyond 50ms for each request. While early return is out of question because of the priority-mechanism, it is yet cheaper to test subsequent candidates for relevant priority before doing the more expensive matching. This change saw processing times of requests reduced by 60% in our case.