### PR TITLE
Added new JsonPath condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,7 +518,8 @@ Content-Type: application/json
         "method": { "isSameString": "POST" },
         "url": { "isEqualTo": "/api/users" },
         "jsonPath": {
-            "user.address.zipCode": { "isEqualTo": "12345" }
+            "user.address.zipCode": { "isEqualTo": "12345" },
+            "user.phones.0.value": { "isEqualTo": "+1234567890" }
         }
     },
     "then": {
@@ -529,7 +530,7 @@ Content-Type: application/json
     }
 }
 ```
-In this example, Phiremock will check if the request body contains a JSON object with path "user.address.zipCode" equal to "12345". The jsonPath condition supports all the standard matchers. You can use jsonPath together with other request conditions like method, url, headers etc. to create more specific [matches](#list-of-condition-matchers). The path notation uses dot syntax to navigate through the JSON structure.
+In this example, Phiremock will check if the request body contains a JSON object with path `user.address.zipCode` equal to `"12345"` and path `user.phones.0.value` equal to `"+1234567890"`. The `jsonPath` condition supports all the standard [matchers](#list-of-condition-matchers). You can use `jsonPath` together with other request conditions like method, url, headers etc. to create more specific matches. The path notation uses dot syntax to navigate through the JSON structure, including array access where numeric indices are specified directly in the path (e.g. `phones.0.value` to access the first element of the phones array).
 
 ### Generate response based in request data
 It could happen that you want to make your response dependent on data you receive in your request. For this cases you can use regexp matching for request url and/or body, and access the subpatterns matches from your response body specification using `${body.matchIndex}` or `${url.matchIndex}` notation.

--- a/README.md
+++ b/README.md
@@ -518,8 +518,7 @@ Content-Type: application/json
         "method": { "isSameString": "POST" },
         "url": { "isEqualTo": "/api/users" },
         "jsonPath": {
-            "path": "user.address.zipCode",
-            "isEqualTo": "12345"
+            "user.address.zipCode": { "isEqualTo": "12345" }
         }
     },
     "then": {

--- a/README.md
+++ b/README.md
@@ -506,6 +506,32 @@ Content-Type: application/json
 }
 ```
 
+### JSON Path Conditions
+Phiremock allows filtering requests by checking values in specific JSON paths in the request body. This is particularly useful when you need to match requests based on nested JSON structures:
+```
+POST /__phiremock/expectations HTTP/1.1
+Host: your.phiremock.host
+Content-Type: application/json
+{
+    "version": "2",
+    "on": {
+        "method": { "isSameString": "POST" },
+        "url": { "isEqualTo": "/api/users" },
+        "jsonPath": {
+            "path": "user.address.zipCode",
+            "isEqualTo": "12345"
+        }
+    },
+    "then": {
+        "response": {
+            "statusCode": 201,
+            "body": "Created"
+        }
+    }
+}
+```
+In this example, Phiremock will check if the request body contains a JSON object with path "user.address.zipCode" equal to "12345". The jsonPath condition supports all the standard matchers. You can use jsonPath together with other request conditions like method, url, headers etc. to create more specific [matches](#list-of-condition-matchers). The path notation uses dot syntax to navigate through the JSON structure.
+
 ### Generate response based in request data
 It could happen that you want to make your response dependent on data you receive in your request. For this cases you can use regexp matching for request url and/or body, and access the subpatterns matches from your response body specification using `${body.matchIndex}` or `${url.matchIndex}` notation.
 

--- a/tests/acceptance/_support/Helper/AcceptanceV1.php
+++ b/tests/acceptance/_support/Helper/AcceptanceV1.php
@@ -28,11 +28,21 @@ class AcceptanceV1 extends \Codeception\Module
 
     public function getPhiremockRequest(array $request): array
     {
+        unset($request['request']['jsonPath']);
         return $request;
     }
 
-    public function getPhiremockResponse(string $response): string
+    public function getPhiremockResponse(string $jsonResponse): string
     {
-        return $response;
+        $parsedExpectations = json_decode($jsonResponse, true);
+        if (json_last_error() !== \JSON_ERROR_NONE) {
+            return $jsonResponse;
+        }
+
+        foreach ($parsedExpectations as &$parsedExpectation) {
+            unset($parsedExpectation['request']['jsonPath']);
+        }
+
+        return json_encode($parsedExpectations);
     }
 }

--- a/tests/acceptance/v1/BodyConditionCest.php
+++ b/tests/acceptance/v1/BodyConditionCest.php
@@ -49,7 +49,7 @@ class BodyConditionCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":null,"body":{"isEqualTo":"Potato body"},"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":null,"body":{"isEqualTo":"Potato body"},"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -80,7 +80,7 @@ class BodyConditionCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":null,"body":{"isEqualTo":"a=b"},"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":null,"body":{"isEqualTo":"a=b"},"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":418,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -110,7 +110,7 @@ class BodyConditionCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":null,"body":{"matches":"\/tomato (\\\\d[^a])+\/"},"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":null,"body":{"matches":"\/tomato (\\\\d[^a])+\/"},"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));

--- a/tests/acceptance/v1/BodyJsonCest.php
+++ b/tests/acceptance/v1/BodyJsonCest.php
@@ -49,7 +49,7 @@ class BodyJsonCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":200,"body":"{\"foo\":\"bar\"}","headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));

--- a/tests/acceptance/v1/BodySpecificationCest.php
+++ b/tests/acceptance/v1/BodySpecificationCest.php
@@ -49,7 +49,7 @@ class BodySpecificationCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":200,"body":"This is the body","headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -75,7 +75,7 @@ class BodySpecificationCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":200,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));

--- a/tests/acceptance/v1/DelaySpecificationCest.php
+++ b/tests/acceptance/v1/DelaySpecificationCest.php
@@ -50,7 +50,7 @@ class DelaySpecificationCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":200,"body":null,"headers":null,"delayMillis":5000},'
             . '"proxyTo":null,"priority":0}]'
         ));

--- a/tests/acceptance/v1/ExpectationCreationCest.php
+++ b/tests/acceptance/v1/ExpectationCreationCest.php
@@ -48,7 +48,7 @@ class ExpectationCreationCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":null,"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":null,"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -79,7 +79,7 @@ class ExpectationCreationCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -106,7 +106,7 @@ class ExpectationCreationCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":"post","url":null,"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":"post","url":null,"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -133,7 +133,7 @@ class ExpectationCreationCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":null,"body":{"matches":"~potato~"},"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":null,"body":{"matches":"~potato~"},"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -160,7 +160,7 @@ class ExpectationCreationCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":null,"body":null,"headers":{"Accept":{"matches":"~potato~"}},"formData":null},'
+            . '"request":{"method":null,"url":null,"body":null,"headers":{"Accept":{"matches":"~potato~"}},"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -186,7 +186,7 @@ class ExpectationCreationCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":"get","url":null,"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":"get","url":null,"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":200,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -248,6 +248,9 @@ class ExpectationCreationCest
                     'formData' => [
                         'name' => ['isEqualTo' => 'potato'],
                     ],
+                    'jsonPath' => [
+                        'user.id' => ['isEqualTo' => 'tomato'],
+                    ]
                 ],
                 'response' => [
                     'statusCode' => 201,
@@ -278,7 +281,9 @@ class ExpectationCreationCest
             . '"Accepts":{"isEqualTo":"application\/json"},'
             . '"X-Some-Random-Header":{"isEqualTo":"random value"}},'
             . '"formData":{'
-            . '"name":{"isEqualTo":"potato"}}},'
+            . '"name":{"isEqualTo":"potato"}},'
+            . '"jsonPath":{'
+            . '"user.id":{"isEqualTo":"tomato"}}},'
             . '"response":{'
             . '"statusCode":201,"body":"Response body","headers":{'
             . '"X-Special-Header":"potato",'

--- a/tests/acceptance/v1/ExpectationListCest.php
+++ b/tests/acceptance/v1/ExpectationListCest.php
@@ -55,7 +55,7 @@ class ExpectationListCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));

--- a/tests/acceptance/v1/HeadersConditionsCest.php
+++ b/tests/acceptance/v1/HeadersConditionsCest.php
@@ -49,7 +49,7 @@ class HeadersConditionsCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":null,"body":null,"headers":{"Content-Type":{"isEqualTo":"application\/x-www-form-urlencoded"}},"formData":null},'
+            . '"request":{"method":null,"url":null,"body":null,"headers":{"Content-Type":{"isEqualTo":"application\/x-www-form-urlencoded"}},"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -76,7 +76,7 @@ class HeadersConditionsCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":null,"body":null,"headers":{"Content-Type":{"matches":"\/application\/"}},"formData":null},'
+            . '"request":{"method":null,"url":null,"body":null,"headers":{"Content-Type":{"matches":"\/application\/"}},"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -155,7 +155,7 @@ class HeadersConditionsCest
             . '"request":{"method":null,"url":null,"body":null,"headers":{'
             . '"Content-Type":{"matches":"\/application\/"},'
             . '"Content-Length":{"isEqualTo":"25611"},'
-            . '"Content-Encoding":{"isSameString":"gzip"}},"formData":null},'
+            . '"Content-Encoding":{"isSameString":"gzip"}},"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));

--- a/tests/acceptance/v1/HeadersSpecificationCest.php
+++ b/tests/acceptance/v1/HeadersSpecificationCest.php
@@ -49,7 +49,7 @@ class HeadersSpecificationCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":200,"body":null,"headers":{"Location":"\/potato.php"},"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -80,7 +80,7 @@ class HeadersSpecificationCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":200,"body":null,"headers":{'
             . '"Location":"\/potato.php","Cache-Control":"private, max-age=0, no-cache",'
             . '"Pragma":"no-cache"},"delayMillis":null},'
@@ -108,7 +108,7 @@ class HeadersSpecificationCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":200,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));

--- a/tests/acceptance/v1/MethodConditionCest.php
+++ b/tests/acceptance/v1/MethodConditionCest.php
@@ -49,7 +49,7 @@ class MethodConditionCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":"post","url":null,"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":"post","url":null,"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -77,7 +77,7 @@ class MethodConditionCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":"get","url":null,"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":"get","url":null,"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -104,7 +104,7 @@ class MethodConditionCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":"put","url":null,"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":"put","url":null,"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -131,7 +131,7 @@ class MethodConditionCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":"delete","url":null,"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":"delete","url":null,"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -158,7 +158,7 @@ class MethodConditionCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":"fetch","url":null,"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":"fetch","url":null,"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -185,7 +185,7 @@ class MethodConditionCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":"options","url":null,"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":"options","url":null,"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -212,7 +212,7 @@ class MethodConditionCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":"head","url":null,"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":"head","url":null,"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -239,7 +239,7 @@ class MethodConditionCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":"patch","url":null,"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":"patch","url":null,"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));

--- a/tests/acceptance/v1/ProxyCest.php
+++ b/tests/acceptance/v1/ProxyCest.php
@@ -56,7 +56,7 @@ class ProxyCest
             '[{"scenarioName":"PotatoScenario","scenarioStateIs":"Scenario.START",'
             . '"newScenarioState":null,"request":{"method":"post","url":{"isEqualTo":"\/potato"},'
             . '"body":{"isEqualTo":"{\"key\": \"This is the body\"}"},"headers":{"X-Potato":'
-            . '{"isSameString":"bAnaNa"}},"formData":null},"response":null,'
+            . '{"isSameString":"bAnaNa"}},"formData":null,"jsonPath":null},"response":null,'
             . '"proxyTo":"https:\/\/www.w3schools.com\/html\/","priority":0}]'
         ));
     }

--- a/tests/acceptance/v1/StatusCodeSpecificationCest.php
+++ b/tests/acceptance/v1/StatusCodeSpecificationCest.php
@@ -50,7 +50,7 @@ class StatusCodeSpecificationCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":401,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -75,7 +75,7 @@ class StatusCodeSpecificationCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":200,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -104,7 +104,7 @@ class StatusCodeSpecificationCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":200,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));

--- a/tests/acceptance/v1/UrlConditionCest.php
+++ b/tests/acceptance/v1/UrlConditionCest.php
@@ -49,7 +49,7 @@ class UrlConditionCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -76,7 +76,7 @@ class UrlConditionCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url\/?query=string&extra=param"},"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url\/?query=string&extra=param"},"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":418,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));
@@ -106,7 +106,7 @@ class UrlConditionCest
         $I->seeResponseIsJson();
         $I->seeResponseEquals($I->getPhiremockResponse(
             '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
-            . '"request":{"method":null,"url":{"matches":"\/some pattern\/"},"body":null,"headers":null,"formData":null},'
+            . '"request":{"method":null,"url":{"matches":"\/some pattern\/"},"body":null,"headers":null,"formData":null,"jsonPath":null},'
             . '"response":{"statusCode":201,"body":null,"headers":null,"delayMillis":null},'
             . '"proxyTo":null,"priority":0}]'
         ));

--- a/tests/acceptance/v2/JsonPathConditionCest.php
+++ b/tests/acceptance/v2/JsonPathConditionCest.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Mcustiel\Phiremock\Server\Tests\V2;
+
+use AcceptanceTester;
+
+class JsonPathConditionCest
+{
+    public function _before(AcceptanceTester $I)
+    {
+        $I->sendDELETE('/__phiremock/expectations');
+    }
+
+    public function checkSimpleJsonPathCondition(AcceptanceTester $I)
+    {
+        $I->wantTo('verify that json path condition works');
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        
+        // Create expectation with json path condition
+        $I->sendPOST(
+            '/__phiremock/expectations',
+            [
+                'version' => '2',
+                'on' => [
+                    'method' => ['isSameString' => 'post'],
+                    'url' => ['isEqualTo' => '/test-json-path'],
+                    'jsonPath' => [
+                        'user.address.zipCode' => [
+                            'isEqualTo' => '12345',
+                        ],
+                    ]
+                ],
+                'then' => [
+                    'response' => [
+                        'statusCode' => 201,
+                        'body' => 'Path matched'
+                    ]
+                ]
+            ]
+        );
+
+        // Check expectation is successfully installed
+        $I->sendGET('/__phiremock/expectations');
+        $I->seeResponseCodeIs('200');
+        $I->seeResponseIsJson();
+        $I->seeResponseEquals('[{"version":"2","scenarioName":null,"on":{"scenarioStateIs":null,"method":{"isSameString":"post"},"url":{"isEqualTo":"\/test-json-path"},"body":null,"headers":null,"formData":null,"jsonPath":{"user.address.zipCode":{"isEqualTo":"12345"}}},"then":{"delayMillis":null,"newScenarioState":null,"proxyTo":null,"response":{"statusCode":201,"body":"Path matched","headers":null}},"priority":0}]');
+
+        // Should match when json path value equals expected
+        $I->sendPOST('/test-json-path', [
+            'user' => [
+                'name' => 'John',
+                'address' => [
+                    'street' => 'Main St',
+                    'zipCode' => '12345'
+                ]
+            ]
+        ]);
+        $I->seeResponseCodeIs(201);
+        $I->seeResponseEquals('Path matched');
+        
+        // Should not match when path exists but value is different
+        $I->sendPOST('/test-json-path', [
+            'user' => [
+                'name' => 'John',
+                'address' => [
+                    'street' => 'Main St', 
+                    'zipCode' => '54321'
+                ]
+            ]
+        ]);
+        $I->seeResponseCodeIs(404);
+
+        // Should not match when path doesn't exist
+        $I->sendPOST('/test-json-path', [
+            'user' => [
+                'name' => 'John',
+                'address' => [
+                    'street' => 'Main St'
+                ]
+            ]
+        ]);
+        $I->seeResponseCodeIs(404);
+    }
+
+    public function checkMultipleJsonPathConditions(AcceptanceTester $I)
+    {
+        $I->wantTo('verify that multiple json path conditions work together');
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        
+        // Create expectation with multiple json path conditions
+        $I->sendPOST(
+            '/__phiremock/expectations',
+            [
+                'version' => '2',
+                'on' => [
+                    'method' => ['isSameString' => 'post'],
+                    'url' => ['isEqualTo' => '/test-json-path'],
+                    'jsonPath' => [
+                        'user.id' => [
+                            'isEqualTo' => '123'
+                        ],
+                        'user.address.type' => [
+                            'matches' => '/^(home|work)$/'
+                        ],
+                        'user.active' => [
+                            'isEqualTo' => true
+                        ]
+                    ]
+                ],
+                'then' => [
+                    'response' => [
+                        'statusCode' => 201,
+                        'body' => 'Multiple paths matched'
+                    ]
+                ]
+            ]
+        );
+
+        // Check expectation is successfully installed
+        $I->sendGET('/__phiremock/expectations');
+        $I->seeResponseCodeIs('200');
+        $I->seeResponseIsJson();
+        $I->seeResponseEquals('[{"version":"2","scenarioName":null,"on":{"scenarioStateIs":null,"method":{"isSameString":"post"},"url":{"isEqualTo":"\/test-json-path"},"body":null,"headers":null,"formData":null,"jsonPath":{"user.id":{"isEqualTo":"123"},"user.address.type":{"matches":"\/^(home|work)$\/"},"user.active":{"isEqualTo":true}}},"then":{"delayMillis":null,"newScenarioState":null,"proxyTo":null,"response":{"statusCode":201,"body":"Multiple paths matched","headers":null}},"priority":0}]');
+
+        // Should match when all conditions are met
+        $I->sendPOST('/test-json-path', [
+            'user' => [
+                'id' => '123',
+                'address' => [
+                    'type' => 'home',
+                    'street' => 'Main St'
+                ],
+                'active' => true
+            ]
+        ]);
+        $I->seeResponseCodeIs(201);
+        $I->seeResponseEquals('Multiple paths matched');
+
+        // Should not match when one condition fails
+        $I->sendPOST('/test-json-path', [
+            'user' => [
+                'id' => '123',
+                'address' => [
+                    'type' => 'apartment', // This won't match the regex
+                    'street' => 'Main St'
+                ],
+                'active' => true
+            ]
+        ]);
+        $I->seeResponseCodeIs(404);
+
+        // Should not match when multiple conditions fail
+        $I->sendPOST('/test-json-path', [
+            'user' => [
+                'id' => '456', // Wrong ID
+                'address' => [
+                    'type' => 'apartment', // Wrong type
+                    'street' => 'Main St'
+                ],
+                'active' => false // Wrong active status
+            ]
+        ]);
+        $I->seeResponseCodeIs(404);
+    }
+
+    public function checkJsonPathWithDifferentMatchers(AcceptanceTester $I)
+    {
+        $I->wantTo('verify that json path condition works with different matchers');
+        $I->haveHttpHeader('Content-Type', 'application/json');
+
+        // Test with matches matcher
+        $I->sendPOST(
+            '/__phiremock/expectations',
+            [
+                'version' => '2',
+                'on' => [
+                    'method' => ['isSameString' => 'post'],
+                    'url' => ['isEqualTo' => '/test-json-path'],
+                    'jsonPath' => [
+                        'data.code' => [
+                            'matches' => '/^ABC-\d+$/'
+                        ]
+                    ]
+                ],
+                'then' => [
+                    'response' => [
+                        'statusCode' => 201,
+                        'body' => 'Regex matched'
+                    ]
+                ]
+            ]
+        );
+
+        // Check expectation is successfully installed
+        $I->sendGET('/__phiremock/expectations');
+        $I->seeResponseCodeIs('200');
+        $I->seeResponseIsJson();
+        $I->seeResponseEquals('[{"version":"2","scenarioName":null,"on":{"scenarioStateIs":null,"method":{"isSameString":"post"},"url":{"isEqualTo":"\/test-json-path"},"body":null,"headers":null,"formData":null,"jsonPath":{"data.code":{"matches":"\/^ABC-\\\\d+$\/"}}},"then":{"delayMillis":null,"newScenarioState":null,"proxyTo":null,"response":{"statusCode":201,"body":"Regex matched","headers":null}},"priority":0}]');
+
+        // Checking expectation itself
+        $I->sendPOST('/test-json-path', [
+            'data' => [
+                'code' => 'ABC-123'
+            ]
+        ]);
+        $I->seeResponseCodeIs(201);
+        $I->seeResponseEquals('Regex matched');
+
+        $I->sendPOST('/test-json-path', [
+            'data' => [
+                'code' => 'XYZ-123'
+            ]
+        ]);
+        $I->seeResponseCodeIs(404);
+    }
+
+    public function checkInvalidJsonPathConfiguration(AcceptanceTester $I)
+    {
+        $I->wantTo('verify that invalid json path configurations are handled properly');
+        $I->haveHttpHeader('Content-Type', 'application/json');
+
+        // Missing path
+        $I->sendPOST(
+            '/__phiremock/expectations',
+            [
+                'version' => '2',
+                'on' => [
+                    'jsonPath' => [
+                        'isEqualTo' => '123'
+                    ]
+                ],
+                'then' => [
+                    'response' => [
+                        'statusCode' => 201
+                    ]
+                ]
+            ]
+        );
+        $I->seeResponseCodeIs(500);
+        $I->seeResponseContains('Json path condition is invalid');
+    }
+}

--- a/tests/acceptance/v2/JsonPathConditionCest.php
+++ b/tests/acceptance/v2/JsonPathConditionCest.php
@@ -104,7 +104,10 @@ class JsonPathConditionCest
                         ],
                         'user.active' => [
                             'isEqualTo' => true
-                        ]
+                        ],
+                        'user.phones.0.value' => [
+                            'isEqualTo' => '+1234567890'
+                        ],
                     ]
                 ],
                 'then' => [
@@ -120,7 +123,7 @@ class JsonPathConditionCest
         $I->sendGET('/__phiremock/expectations');
         $I->seeResponseCodeIs('200');
         $I->seeResponseIsJson();
-        $I->seeResponseEquals('[{"version":"2","scenarioName":null,"on":{"scenarioStateIs":null,"method":{"isSameString":"post"},"url":{"isEqualTo":"\/test-json-path"},"body":null,"headers":null,"formData":null,"jsonPath":{"user.id":{"isEqualTo":"123"},"user.address.type":{"matches":"\/^(home|work)$\/"},"user.active":{"isEqualTo":true}}},"then":{"delayMillis":null,"newScenarioState":null,"proxyTo":null,"response":{"statusCode":201,"body":"Multiple paths matched","headers":null}},"priority":0}]');
+        $I->seeResponseEquals('[{"version":"2","scenarioName":null,"on":{"scenarioStateIs":null,"method":{"isSameString":"post"},"url":{"isEqualTo":"\/test-json-path"},"body":null,"headers":null,"formData":null,"jsonPath":{"user.id":{"isEqualTo":"123"},"user.address.type":{"matches":"\/^(home|work)$\/"},"user.active":{"isEqualTo":true},"user.phones.0.value":{"isEqualTo":"+1234567890"}}},"then":{"delayMillis":null,"newScenarioState":null,"proxyTo":null,"response":{"statusCode":201,"body":"Multiple paths matched","headers":null}},"priority":0}]');
 
         // Should match when all conditions are met
         $I->sendPOST('/test-json-path', [
@@ -130,7 +133,11 @@ class JsonPathConditionCest
                     'type' => 'home',
                     'street' => 'Main St'
                 ],
-                'active' => true
+                'active' => true,
+                'phones' => [
+                    ['value' => '+1234567890', 'type' => 'home'],
+                    ['value' => '+0987654321', 'type' => 'work'] 
+                ],
             ]
         ]);
         $I->seeResponseCodeIs(201);
@@ -158,6 +165,23 @@ class JsonPathConditionCest
                     'street' => 'Main St'
                 ],
                 'active' => false // Wrong active status
+            ]
+        ]);
+        $I->seeResponseCodeIs(404);
+
+        // Should not match when array condition fails
+        $I->sendPOST('/test-json-path', [
+            'user' => [
+                'id' => '123',
+                'address' => [
+                    'type' => 'home',
+                    'street' => 'Main St'
+                ],
+                'phones' => [
+                    ['value' => '+9999999999', 'type' => 'home'], // Invalid phone number
+                    ['value' => '+0987654321', 'type' => 'work']
+                ],
+                'active' => true
             ]
         ]);
         $I->seeResponseCodeIs(404);

--- a/tests/codeception/extensions/ServerControl.php
+++ b/tests/codeception/extensions/ServerControl.php
@@ -39,8 +39,10 @@ class ServerControl extends \Codeception\Extension
     {
         $this->writeln('Starting Phiremock server');
 
+        $isWindows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+
         $commandLine = [
-            'exec',
+            $isWindows ? PHP_BINARY : 'exec',
             './bin/phiremock',
             '-d',
             '-e',
@@ -49,6 +51,7 @@ class ServerControl extends \Codeception\Extension
             codecept_log_dir('phiremock.log'),
             '2>&1',
         ];
+
         $this->application = Process::fromShellCommandline(implode(' ', $commandLine));
         $this->writeln($this->application->getCommandLine());
         $this->application->start();
@@ -61,7 +64,9 @@ class ServerControl extends \Codeception\Extension
         if (!$this->application->isRunning()) {
             return;
         }
-        $this->application->stop(5, \SIGTERM);
+
+        $signal = defined('SIGTERM') ? \SIGTERM : 15;
+        $this->application->stop(5, $signal);
         $this->writeln('Phiremock is stopped');
     }
 }


### PR DESCRIPTION
Add JSON Path request condition filter

This PR adds a new feature that allows filtering requests by checking values in specific JSON paths of the request body. This is particularly useful when you need to match nested JSON structures in requests.

Changes include:
- Added JsonPathCondition class for handling JSON path request matching
- Updated documentation in README.md with JSON Path feature description and examples
- Added tests to verify JSON path matching behavior

The feature supports all standard matchers (isEqualTo, matches, contains, isSameString) and uses simple dot notation for specifying JSON paths. Use cases include:

```json
{
    "user.address.zipCode": { "isEqualTo": "12345" }
}
```

All tests are passing