### PR TITLE
Fix binary response handling with regex conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ vendor/
 .buildpath
 .project
 .settings
+.vscode
 composer.lock
 tests/_output
 tests/_support/_generated

--- a/src/Utils/Strategies/RegexResponseStrategy.php
+++ b/src/Utils/Strategies/RegexResponseStrategy.php
@@ -20,6 +20,7 @@ namespace Mcustiel\Phiremock\Server\Utils\Strategies;
 
 use Mcustiel\Phiremock\Common\StringStream;
 use Mcustiel\Phiremock\Domain\Expectation;
+use Mcustiel\Phiremock\Domain\Http\BinaryBody;
 use Mcustiel\Phiremock\Domain\HttpResponse;
 use Mcustiel\Phiremock\Server\Model\ScenarioStorage;
 use Mcustiel\Phiremock\Server\Utils\Strategies\Utils\RegexReplacer;
@@ -72,10 +73,14 @@ class RegexResponseStrategy extends AbstractResponse implements ResponseStrategy
         $responseConfig = $expectation->getResponse();
 
         if ($responseConfig->hasBody()) {
-            $bodyString = $responseConfig->getBody()->asString();
-            $bodyString = $this->regexReplacer->fillWithUrlMatches($expectation, $httpRequest, $bodyString);
-            $bodyString = $this->regexReplacer->fillWithBodyMatches($expectation, $httpRequest, $bodyString);
-            $httpResponse = $httpResponse->withBody(new StringStream($bodyString));
+            if ($responseConfig->getBody() instanceof BinaryBody) {
+                $httpResponse = $httpResponse->withBody($responseConfig->getBody()->asStream());
+            } else {
+                $bodyString = $responseConfig->getBody()->asString();
+                $bodyString = $this->regexReplacer->fillWithUrlMatches($expectation, $httpRequest, $bodyString);
+                $bodyString = $this->regexReplacer->fillWithBodyMatches($expectation, $httpRequest, $bodyString);
+                $httpResponse = $httpResponse->withBody(new StringStream($bodyString));
+            }
         }
 
         return $httpResponse;

--- a/tests/acceptance/v1/BinaryContentCest.php
+++ b/tests/acceptance/v1/BinaryContentCest.php
@@ -55,4 +55,31 @@ class BinaryContentCest
         $responseBody = $I->grabResponse();
         $I->assertEquals($responseContents, $responseBody);
     }
+
+    public function shouldCreateAnExpectationWithBinaryResponseAndRegexUrl(AcceptanceTester $I)
+    {
+        $responseContents = file_get_contents(Configuration::dataDir() . 'fixtures/silhouette-1444982_640.png');
+
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        $I->sendPOST(
+            '/__phiremock/expectations',
+            $I->getPhiremockRequest([
+                'request' => [
+                    'url' => ['matches' => '/\/show-me-the-image-\d+/'],
+                ],
+                'response' => [
+                    'headers' => [
+                        'Content-Type'     => 'image/jpeg',
+                    ],
+                    'body' => 'phiremock.base64:' . base64_encode($responseContents),
+                ],
+            ])
+        );
+
+        $I->sendGET('/show-me-the-image-123');
+        $I->seeResponseCodeIs(200);
+        $I->seeHttpHeader('Content-Type', 'image/jpeg');
+        $responseBody = $I->grabResponse();
+        $I->assertEquals($responseContents, $responseBody);
+    }
 }


### PR DESCRIPTION
When using regex conditions (for URL or body) with binary response body, the content was incorrectly returned as a string with 'phiremock.base64:' prefix instead of actual binary data. 

This PR fixes the issue by:
- Adding a check for BinaryBody instance in RegexResponseStrategy
- Bypassing regex replacement logic for binary responses since substitutions from regex capture groups are not applicable for binary data
- Adding a test case to verify binary response works correctly with regex URL matching

The change ensures binary responses (like images) are properly handled regardless of whether regex conditions are used in the expectation.