### PR TITLE
Upgrading the symfony version for composer.json and composer.phar.json

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -14,27 +14,19 @@ build:
       - php-scrutinizer-run
       - ./vendor/bin/codecept run
   nodes:
-    php72:
-      environment:
-        php:
-          version: 7.2
-    php73:
-      environment:
-        php:
-          version: 7.3
-    php74:
-      environment:
-        php:
-          version: 7.4
-    php80:
-      environment:
-        php:
-          version: 8.0
-    php81:
-      environment:
-        php:
-          version: 8.1
     php82:
       environment:
         php:
           version: 8.2
+    php83:
+      environment:
+        php:
+          version: 8.3
+    php84:
+      environment:
+        php:
+          version: 8.4
+    php85:
+      environment:
+        php:
+          version: 8.5

--- a/bin/phiremock.php
+++ b/bin/phiremock.php
@@ -33,6 +33,6 @@ if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
 
 $application = new Application('Phiremock', '');
 $phiremockServerCommand = new PhiremockServerCommand();
-$application->add($phiremockServerCommand);
+$application->addCommand($phiremockServerCommand);
 $application->setDefaultCommand($phiremockServerCommand->getName(), IS_SINGLE_COMMAND);
 $application->run();

--- a/codeception.yml
+++ b/codeception.yml
@@ -5,6 +5,7 @@ paths:
     data: tests/acceptance/_data
     support: tests/acceptance/_support
     envs: tests/acceptance/_envs
+    output: tests/acceptance/_output
 settings:
     colors: true
     memory_limit: 1024M

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "psr/http-client": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^13.0",
+        "phpunit/phpunit": "^11.0",
         "codeception/codeception": "^5.1",
         "codeception/module-asserts": "^3.3",
         "codeception/module-rest": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "mcustiel/phiremock-common": "^1.0",
         "react/http": "^1.0",
         "monolog/monolog": ">=1.0 <4.0",
-        "symfony/console": ">=3.0 <8.0",
+        "symfony/console": ">=3.0 <9.0",
         "nikic/fast-route": "^1.3.0",
         "psr/http-client": "^1.0"
     },
@@ -35,7 +35,7 @@
         "codeception/module-asserts": "^1.0",
         "codeception/module-rest": "^1.0",
         "codeception/module-phpbrowser": "^1.0",
-        "symfony/process": ">=3.0 <8.0",
+        "symfony/process": ">=3.0 <9.0",
         "guzzlehttp/guzzle" : "^6.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,23 +20,24 @@
     "description": "A mocker for HTTP and REST services",
     "license": "GPL-3.0-or-later",
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^8.2",
         "ext-json": "*",
+        "ext-dom": "*",
         "mcustiel/phiremock-common": "^1.0",
         "react/http": "^1.0",
-        "monolog/monolog": ">=1.0 <4.0",
-        "symfony/console": ">=3.0 <9.0",
+        "monolog/monolog": "^2.0|^3.0",
+        "symfony/console": ">=6.0 <9.0",
         "nikic/fast-route": "^1.3.0",
         "psr/http-client": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0|^9.0",
-        "codeception/codeception": "^4.0",
-        "codeception/module-asserts": "^1.0",
-        "codeception/module-rest": "^1.0",
-        "codeception/module-phpbrowser": "^1.0",
-        "symfony/process": ">=3.0 <9.0",
-        "guzzlehttp/guzzle" : "^6.0"
+        "phpunit/phpunit": "^13.0",
+        "codeception/codeception": "^5.1",
+        "codeception/module-asserts": "^3.3",
+        "codeception/module-rest": "^3.4",
+        "codeception/module-phpbrowser": "^4.0",
+        "symfony/process": ">=6.4 <9.0",
+        "guzzlehttp/guzzle" : "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.phar.json
+++ b/composer.phar.json
@@ -32,7 +32,7 @@
         "guzzlehttp/guzzle" : "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^13.0",
+        "phpunit/phpunit": "^11.0",
         "codeception/codeception": "^5.1",
         "codeception/module-asserts": "^3.3",
         "codeception/module-rest": "^3.4",

--- a/composer.phar.json
+++ b/composer.phar.json
@@ -24,7 +24,7 @@
         "mcustiel/phiremock-common": "^1.0",
         "react/http": "^1.0",
         "monolog/monolog": "^2.0|^3.0",
-        "symfony/console": ">=4.0 <7.0",
+        "symfony/console": ">=4.0 <9.0",
         "nikic/fast-route": "^1.3.0",
         "psr/http-client": "^1.0",
         "guzzlehttp/guzzle" : "^6.0"
@@ -35,7 +35,7 @@
         "codeception/module-asserts": "^1.0",
         "codeception/module-rest": "^1.0",
         "codeception/module-phpbrowser": "^1.0",
-        "symfony/process": ">=3.0 <7.0"
+        "symfony/process": ">=3.0 <9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.phar.json
+++ b/composer.phar.json
@@ -20,22 +20,24 @@
     "description": "A mocker for HTTP and REST services",
     "license": "GPL-3.0-or-later",
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^8.2",
+        "ext-json": "*",
+        "ext-dom": "*",
         "mcustiel/phiremock-common": "^1.0",
         "react/http": "^1.0",
         "monolog/monolog": "^2.0|^3.0",
-        "symfony/console": ">=4.0 <9.0",
+        "symfony/console": ">=6.0 <9.0",
         "nikic/fast-route": "^1.3.0",
         "psr/http-client": "^1.0",
-        "guzzlehttp/guzzle" : "^6.0"
+        "guzzlehttp/guzzle" : "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0|^9.0",
-        "codeception/codeception": "^4.0",
-        "codeception/module-asserts": "^1.0",
-        "codeception/module-rest": "^1.0",
-        "codeception/module-phpbrowser": "^1.0",
-        "symfony/process": ">=3.0 <9.0"
+        "phpunit/phpunit": "^13.0",
+        "codeception/codeception": "^5.1",
+        "codeception/module-asserts": "^3.3",
+        "codeception/module-rest": "^3.4",
+        "codeception/module-phpbrowser": "^4.0",
+        "symfony/process": ">=6.4 <9.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/acceptance/common.suite.yml
+++ b/tests/acceptance/common.suite.yml
@@ -1,4 +1,4 @@
-class_name: CommonTester
+actor: CommonTester
 suite_namespace: Mcustiel/Phiremock/Server/Tests/Common
 modules:
     enabled:

--- a/tests/acceptance/v1.suite.yml
+++ b/tests/acceptance/v1.suite.yml
@@ -1,4 +1,4 @@
-class_name: AcceptanceTester
+actor: AcceptanceTester
 suite_namespace: Mcustiel/Phiremock/Server/Tests/V1
 modules:
     enabled:

--- a/tests/acceptance/v2.suite.yml
+++ b/tests/acceptance/v2.suite.yml
@@ -1,4 +1,4 @@
-class_name: AcceptanceTester
+actor: AcceptanceTester
 suite_namespace: Mcustiel/Phiremock/Server/Tests/V2
 modules:
     enabled:


### PR DESCRIPTION
The symfony version for composer.json and composer.phar.json was upgraded to enable version 8.